### PR TITLE
Update DecisionTreeRegression.ipynb to correct typos

### DIFF
--- a/Nicole Code/DecisionTreeRegression.ipynb
+++ b/Nicole Code/DecisionTreeRegression.ipynb
@@ -759,7 +759,7 @@
         "mse_pruned = mean_squared_error(y_test, y_pred_pruned)\n",
         "rmse = np.sqrt(mse)\n",
         "r2 = r2_score(y_test, y_pred)\n",
-        "print(f'Mean Squared Error on the Sony test set (Pruned): {mse_pruned:.2f}')\n",
+        "print(f'Mean Squared Error on the PS2 test set (Pruned): {mse_pruned:.2f}')\n",
         "print(f'Root Mean Squared Error: {rmse:.2f}')\n",
         "print(f'R-squared: {r2:.2f}')\n",
         "\n",
@@ -784,7 +784,7 @@
           "name": "stdout",
           "text": [
             "Best ccp_alpha: 0.0\n",
-            "Mean Squared Error on the Sony test set (Pruned): 0.08\n",
+            "Mean Squared Error on the PS2 test set (Pruned): 0.08\n",
             "Root Mean Squared Error: 0.10\n",
             "R-squared: 0.98\n"
           ]


### PR DESCRIPTION
Correcting typo to change "Sony" to "PS2" for the pruning of PS2 tree section